### PR TITLE
feat: V2 Core completion — openProject, saveProjectAs, docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Open Project: Projektordner via Dialog oeffnen, State + Video laden
+- Save As: Projekt unter neuem Pfad speichern (inkl. Verzeichnis-Erstellung)
+- IPC-Channels `dialog:openProject` und `dialog:saveProject`
+
+## [2.0.0] - 2026-03-04
+
+### Added
+- **V2 Migration:** Komplette Neuentwicklung mit Svelte 5 + TypeScript
+- Svelte 5 Runes-basiertes State-Management (ersetzt V1 AppState)
+- Typisierte IPC-Bridge (5-Schichten-Architektur)
+- electron-vite Build-System mit Hot-Reload
+- Vitest Unit-Tests (154 Tests)
+- ESLint + Prettier Konfiguration
+
 ### Changed
 - dialogManager: Alle Dialog-Funktionen akzeptieren optionalen `parentWindow` Parameter fuer macOS Sheet-Modals (#164)
 - videoActions/shortcuts: `register*`-Funktionen akzeptieren `null` zum sauberen Deregistrieren

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,22 +1,111 @@
 # CLAUDE.md — ShotSheetEditor
 
 ## Tech Stack
-<!-- Bitte ausfüllen: z.B. TypeScript, React, Node.js, SQLite -->
+- **Runtime:** Electron 34 (Chromium + Node.js)
+- **Build-Tool:** electron-vite 5 + Vite 7
+- **Frontend:** Svelte 5 (Runes, `.svelte.ts` Stores) + TypeScript 5.9
+- **Styling:** Vanilla CSS mit Custom Properties (Design Tokens in `tokens.css`)
+- **Tests:** Vitest 4
+- **Linting:** ESLint 10 + Prettier 3
+- **Packaging:** electron-builder 26
+- **Dependencies (Runtime):** archiver (ZIP-Export), ffmpeg/ffprobe (gebundelt oder System)
 
 ## Projektstruktur
-<!-- Kurze Beschreibung der wichtigsten Ordner -->
+```
+src/
+  main/              — Electron Main-Process (Node.js)
+    index.ts         — App-Lifecycle, Menue, Window-Erstellung
+    ipcHandlers.ts   — Alle IPC-Handler (Sicherheits-Grenze)
+    ffmpegBridge.ts  — FFmpeg/FFprobe Pfad-Aufloesung + Caching
+    frameExtractor.ts — Thumbnail-Extraktion (concurrent, MAX=5)
+    exportManager.ts — ZIP + Sequenz-Export
+    proxyGenerator.ts — Proxy-Video-Generierung (H.264 720p)
+    projectManager.ts — Projekt laden/speichern (Atomic Write)
+    sceneDetector.ts — Scene Detection via ffmpeg
+    windowManager.ts — BrowserWindow + State-Persistenz
+    dialogManager.ts — Native Dialoge (Open/Save/Confirm)
+    videoManager.ts  — Video-Metadaten via ffprobe
+  preload/           — Context Bridge (Sicherheits-Grenze)
+    index.ts         — contextBridge.exposeInMainWorld()
+    types.ts         — ElectronAPI Interface-Definition
+  renderer/          — Svelte 5 Frontend
+    src/
+      components/    — Svelte-Komponenten (Grid, Player, Toolbar, etc.)
+      lib/
+        actions/     — Business-Logik (videoActions, projectActions, etc.)
+        ipc/bridge.ts — Typisierter Wrapper um window.electronAPI
+        stores/      — Svelte 5 Runes Stores (.svelte.ts)
+      App.svelte     — Root-Komponente
+      main.ts        — Entry-Point
+    index.html       — App-Shell
+  shared/            — Von Main + Renderer gemeinsam genutzt
+    constants.ts     — Re-Exports aus Submodulen
+    ipcChannels.ts   — IPC Channel-Konstanten (as const)
+    ipcPayloads.ts   — Request/Response Types fuer alle IPC-Calls
+    models.ts        — Domain-Types (Scene, Collection, VideoMeta, etc.)
+tests/
+  unit/              — Vitest Unit-Tests
+docs/                — Architektur-Dokumentation
+```
 
 ## Wichtige Befehle
 ```bash
-# Entwicklung starten
-# npm run dev
+# Entwicklung starten (Hot-Reload)
+npm run dev
 
-# Build
-# npm run build
+# TypeScript pruefen (ohne Build)
+npx tsc --noEmit
 
-# Tests
-# npm run test
+# Tests ausfuehren
+npm run test
+
+# Tests im Watch-Modus
+npm run test:watch
+
+# Build (alle Plattformen)
+npm run build
+
+# macOS DMG bauen
+npm run build:mac
+
+# Linting
+npm run lint
+
+# Formatierung
+npm run format
 ```
 
+## Architektur-Patterns
+
+### IPC-Schichten (5 Layer)
+1. `ipcChannels.ts` — Channel-Strings als `as const`
+2. `preload/types.ts` — `ElectronAPI` Interface
+3. `preload/index.ts` — `contextBridge.exposeInMainWorld()`
+4. `main/ipcHandlers.ts` — Handler mit Validierung + wrapHandler()
+5. `renderer/lib/ipc/bridge.ts` — Typisierte Wrapper-Funktionen
+
+Neue IPC-Methode = immer alle 5 Schichten aendern.
+
+### State-Management (Svelte 5 Runes)
+- Stores in `lib/stores/*.svelte.ts` mit `$state()` Runes
+- Getter/Setter-Funktionen (kein direkter Store-Zugriff)
+- `resetAllStores()` fuer File → New
+- UndoRedo: `commit()` MUSS vor State-Aenderung aufgerufen werden
+
+### Actions-Pattern
+- Business-Logik in `lib/actions/*.ts`
+- Actions importieren Stores und IPC-Bridge
+- Komponenten rufen nur Actions auf, nie direkt IPC
+
+### Security
+- Alle Pfade gegen `os.homedir()` validieren (Path Traversal)
+- `fs.realpathSync()` statt `path.resolve()` (Symlink-Schutz)
+- Codec gegen Whitelist pruefen
+- CSP in index.html
+
 ## Projektspezifische Konventionen
-<!-- Besonderheiten die über die globale CLAUDE.md hinausgehen -->
+- Svelte-Komponenten: PascalCase (`ShotGrid.svelte`)
+- Store-Dateien: camelCase mit `.svelte.ts` Extension
+- IPC-Channels: `domain:action` Format (`video:open`, `project:save`)
+- Alle IPC-Handler muessen in `wrapHandler()` gewrappt werden
+- Keine anonymen Event-Listener (fuer Cleanup)

--- a/src/main/ipcHandlers.ts
+++ b/src/main/ipcHandlers.ts
@@ -8,7 +8,7 @@ import { detectScenes, cancelDetection } from './sceneDetector'
 import { extractFrames } from './frameExtractor'
 import { exportSequence, exportZip } from './exportManager'
 import { newProject, openProject, saveProject } from './projectManager'
-import { showExportDirDialog, showOpenVideoDialog, showUnsavedChangesDialog } from './dialogManager'
+import { showExportDirDialog, showOpenVideoDialog, showOpenProjectDialog, showSaveProjectDialog, showUnsavedChangesDialog } from './dialogManager'
 import { toggleTheme, getThemeSource } from './windowManager'
 import { getFFmpegPath, validateFFmpeg } from './ffmpegBridge'
 import { needsTranscoding, generateProxy, cancelTranscoding } from './proxyGenerator'
@@ -356,6 +356,32 @@ export function registerIpcHandlers(getMainWindow: WindowGetter): void {
         return { success: false, error: 'Canceled' }
       }
       return { success: true, path: result.filePaths[0] }
+    } catch (error) {
+      return { success: false, error: (error as Error).message }
+    }
+  })
+
+  ipcMain.handle(IPC_CHANNELS.DIALOG_OPEN_PROJECT, async () => {
+    try {
+      const win = getMainWindow()
+      const result = await showOpenProjectDialog(win || undefined)
+      if (result.canceled) {
+        return { success: false, error: 'Canceled' }
+      }
+      return { success: true, path: result.filePaths[0] }
+    } catch (error) {
+      return { success: false, error: (error as Error).message }
+    }
+  })
+
+  ipcMain.handle(IPC_CHANNELS.DIALOG_SAVE_PROJECT, async () => {
+    try {
+      const win = getMainWindow()
+      const result = await showSaveProjectDialog(win || undefined)
+      if (result.canceled) {
+        return { success: false, error: 'Canceled' }
+      }
+      return { success: true, path: result.filePath }
     } catch (error) {
       return { success: false, error: (error as Error).message }
     }

--- a/src/main/projectManager.ts
+++ b/src/main/projectManager.ts
@@ -182,6 +182,9 @@ export function saveProject(
       return { success: false, error: 'Project path must be within home directory' }
     }
 
+    // Verzeichnis erstellen falls noetig (Save As in neuen Ordner)
+    fs.mkdirSync(projectPath, { recursive: true })
+
     const projectJsonPath = path.join(projectPath, 'project.json')
 
     // Atomic Write: Temp-Datei schreiben, dann umbenennen

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -53,6 +53,8 @@ const api: ElectronAPI = {
 
   // Dialoge
   openVideoDialog: () => ipcRenderer.invoke('dialog:openVideo'),
+  openProjectDialog: () => ipcRenderer.invoke('dialog:openProject'),
+  saveProjectDialog: () => ipcRenderer.invoke('dialog:saveProject'),
   unsavedChangesDialog: () => ipcRenderer.invoke('dialog:unsavedChanges'),
 
   // ===== Listener: Main -> Renderer =====

--- a/src/preload/types.ts
+++ b/src/preload/types.ts
@@ -84,6 +84,8 @@ export interface ElectronAPI {
 
   // Dialoge
   openVideoDialog: () => Promise<DialogResponse>
+  openProjectDialog: () => Promise<DialogResponse>
+  saveProjectDialog: () => Promise<DialogResponse>
   unsavedChangesDialog: () => Promise<DialogResponse>
 
   // ===== Listener: Main -> Renderer (fire & forget) =====

--- a/src/renderer/src/lib/actions/projectActions.ts
+++ b/src/renderer/src/lib/actions/projectActions.ts
@@ -26,7 +26,7 @@ import {
 import { resetSelectionState, setFavoriteIndices, setDeletedIndices } from '../stores'
 import * as undoRedo from './undoRedo'
 import { showToast } from './toastManager'
-import { registerPauseAndReset } from './videoActions'
+import { openVideoFromPath, callPauseAndReset } from './videoActions'
 
 /**
  * Neues Projekt erstellen — State zurücksetzen
@@ -86,15 +86,109 @@ export async function saveProject(): Promise<void> {
 }
 
 /**
- * Save As — TODO: Dialog implementieren
+ * Save As — neuen Speicherort wählen und Projekt dort speichern
  */
 export async function saveProjectAs(): Promise<void> {
-  showToast('Save As — coming soon', 'info')
+  const videoPath = getVideoPath()
+  if (!videoPath) {
+    showToast('No video loaded — nothing to save', 'warning')
+    return
+  }
+
+  try {
+    const dialogResult = await ipc.saveProjectDialog()
+    if (!dialogResult?.success || !dialogResult.path) return
+
+    const newPath = dialogResult.path
+
+    const data = {
+      videoPath,
+      scenes: getScenes(),
+      favoriteIndices: getFavoriteIndices(),
+      deletedIndices: getDeletedIndices(),
+      collections: getCollections(),
+      threshold: getThreshold(),
+      gridSize: getGridSize(),
+    }
+
+    const result = await ipc.saveProject(newPath, data)
+    if (result?.success) {
+      setProjectPath(newPath)
+      setIsDirty(false)
+      showToast('Project saved', 'success')
+    } else {
+      showToast(result?.error ?? 'Failed to save project', 'error')
+    }
+  } catch (err) {
+    console.error('projectActions: saveProjectAs failed', err)
+    showToast('Failed to save project', 'error')
+  }
 }
 
 /**
- * Projekt öffnen — TODO: Dialog implementieren
+ * Projekt öffnen — Verzeichnis wählen, project.json laden, State befüllen
  */
 export async function openProject(): Promise<void> {
-  showToast('Open Project — coming soon', 'info')
+  // isDirty-Check — ungespeicherte Aenderungen abfragen
+  if (getIsDirty()) {
+    try {
+      const confirmResult = await ipc.unsavedChangesDialog()
+      if (!confirmResult?.success) return
+      const response = confirmResult.response as unknown as string
+      if (response === 'cancel') return
+      if (response === 'save') {
+        await saveProject()
+      }
+      // 'discard' → weiter ohne speichern
+    } catch {
+      return
+    }
+  }
+
+  try {
+    // Dialog: Projektordner wählen
+    const dialogResult = await ipc.openProjectDialog()
+    if (!dialogResult?.success || !dialogResult.path) return
+
+    // Projekt laden via Main-Process
+    const result = await ipc.openProject(dialogResult.path)
+    if (!result?.success) {
+      showToast(result?.error ?? 'Failed to open project', 'error')
+      return
+    }
+
+    const data = result.data as Record<string, unknown> | undefined
+
+    // Video stoppen + State zuruecksetzen
+    callPauseAndReset()
+    resetSelectionState()
+    undoRedo.clear()
+
+    // State aus Projektdaten befuellen (defensive Defaults)
+    const scenes = (data?.scenes as unknown[]) ?? []
+    setScenes(scenes as ReturnType<typeof getScenes>)
+    setCollections((data?.collections as ReturnType<typeof getCollections>) ?? [])
+    setFavoriteIndices((data?.favoriteIndices as number[]) ?? [])
+    setDeletedIndices((data?.deletedIndices as number[]) ?? [])
+    setThreshold((data?.threshold as number) ?? 0.3)
+    setGridSize((data?.gridSize as number) ?? 200)
+    setProjectPath(dialogResult.path)
+    setCurrentShotIdx(-1)
+    setIsDirty(false)
+
+    // Video laden (falls vorhanden)
+    const videoPath = data?.videoPath as string | undefined
+    if (videoPath) {
+      try {
+        await openVideoFromPath(videoPath, { skipStateReset: true })
+      } catch {
+        showToast('Project loaded, but video file not found', 'warning')
+      }
+    }
+
+    showToast('Project loaded', 'success')
+  } catch (err) {
+    console.error('projectActions: openProject failed', err)
+    showToast('Failed to open project', 'error')
+  }
 }

--- a/src/renderer/src/lib/actions/videoActions.ts
+++ b/src/renderer/src/lib/actions/videoActions.ts
@@ -51,12 +51,21 @@ export async function openVideo(): Promise<void> {
   }
 }
 
+/** Optionen fuer openVideoFromPath */
+interface OpenVideoOptions {
+  /** Wenn true: State-Reset ueberspringen (fuer openProject) */
+  skipStateReset?: boolean
+}
+
 /**
  * Video per Pfad laden — Metadaten holen, Codec prüfen, ggf. Proxy generieren.
- * Wird von openVideo() und Drag&Drop aufgerufen.
+ * Wird von openVideo(), Drag&Drop und openProject aufgerufen.
  * Race-Condition-Guards nach jedem await (Fix #125).
  */
-export async function openVideoFromPath(filePath: string): Promise<void> {
+export async function openVideoFromPath(
+  filePath: string,
+  options?: OpenVideoOptions,
+): Promise<void> {
   try {
     // Laufendes Transcoding abbrechen
     if (getIsTranscoding()) {
@@ -72,20 +81,26 @@ export async function openVideoFromPath(filePath: string): Promise<void> {
       return
     }
 
-    // Fallback-Projektverzeichnis
-    const videoDir =
-      filePath.substring(0, filePath.lastIndexOf('/')) ||
-      filePath.substring(0, filePath.lastIndexOf('\\'))
+    if (options?.skipStateReset) {
+      // Nur Video-Pfad und Meta setzen (openProject hat State schon befuellt)
+      setVideoPath(filePath)
+      setVideoMeta(meta)
+    } else {
+      // Fallback-Projektverzeichnis
+      const videoDir =
+        filePath.substring(0, filePath.lastIndexOf('/')) ||
+        filePath.substring(0, filePath.lastIndexOf('\\'))
 
-    // State zurücksetzen für neues Video
-    setVideoPath(filePath)
-    setVideoMeta(meta)
-    setScenes([])
-    resetSelectionState()
-    setCurrentShotIdx(-1)
-    setProjectPath(videoDir)
-    setIsDirty(true)
-    undoRedo.clear()
+      // State zurücksetzen für neues Video
+      setVideoPath(filePath)
+      setVideoMeta(meta)
+      setScenes([])
+      resetSelectionState()
+      setCurrentShotIdx(-1)
+      setProjectPath(videoDir)
+      setIsDirty(true)
+      undoRedo.clear()
+    }
 
     const duration = meta.data?.duration ?? 0
 

--- a/src/renderer/src/lib/ipc/bridge.ts
+++ b/src/renderer/src/lib/ipc/bridge.ts
@@ -134,6 +134,14 @@ export function openVideoDialog(): Promise<DialogResponse> {
   return api().openVideoDialog()
 }
 
+export function openProjectDialog(): Promise<DialogResponse> {
+  return api().openProjectDialog()
+}
+
+export function saveProjectDialog(): Promise<DialogResponse> {
+  return api().saveProjectDialog()
+}
+
 export function unsavedChangesDialog(): Promise<DialogResponse> {
   return api().unsavedChangesDialog()
 }

--- a/src/shared/ipcChannels.ts
+++ b/src/shared/ipcChannels.ts
@@ -40,6 +40,8 @@ export const IPC_CHANNELS = {
 
   // Dialoge
   DIALOG_OPEN_VIDEO: 'dialog:openVideo',
+  DIALOG_OPEN_PROJECT: 'dialog:openProject',
+  DIALOG_SAVE_PROJECT: 'dialog:saveProject',
   DIALOG_UNSAVED_CHANGES: 'dialog:unsavedChanges',
 
   // Menue (Main -> Renderer)


### PR DESCRIPTION
## Summary
- **openProject()**: Full IPC roundtrip — dialog → load project.json → restore state (scenes, collections, favorites, deleted, threshold, gridSize) → load video with `skipStateReset`. Includes isDirty check, defensive defaults for corrupt JSON, video-not-found fallback toast.
- **saveProjectAs()**: Dialog → mkdirSync for new directories → save project.json → update projectPath + isDirty. Guards against no-video state.
- **IPC infrastructure**: `dialog:openProject` + `dialog:saveProject` channels added across all 5 layers (ipcChannels → types → preload → ipcHandlers → bridge)
- **projectManager.ts**: `mkdirSync` before atomic write enables Save As to new directories
- **CLAUDE.md**: Tech stack, project structure, commands, architecture patterns fully documented
- **CHANGELOG.md**: `[Unreleased]` → `[2.0.0] - 2026-03-04` release, new Unreleased block with openProject/saveProjectAs
- **67 V1 issues closed**: All superseded by V2 migration

## Changed files (10)
| File | Change |
|------|--------|
| `src/shared/ipcChannels.ts` | +2 dialog channels |
| `src/preload/types.ts` | +2 interface methods |
| `src/preload/index.ts` | +2 invoke calls |
| `src/main/ipcHandlers.ts` | +2 handlers, +2 imports |
| `src/main/projectManager.ts` | +mkdirSync before write |
| `src/renderer/src/lib/ipc/bridge.ts` | +2 wrappers |
| `src/renderer/src/lib/actions/videoActions.ts` | +skipStateReset option |
| `src/renderer/src/lib/actions/projectActions.ts` | openProject + saveProjectAs |
| `CLAUDE.md` | Full documentation |
| `CHANGELOG.md` | V2.0.0 release |

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npm run test` — 154 tests pass
- [ ] Manual: File → Open Project → select folder → scenes + video load
- [ ] Manual: File → Save As → new folder → project.json created
- [ ] Manual: Make changes → File → Open → isDirty dialog appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)